### PR TITLE
Fix(frontend): Correct data handling for player roles

### DIFF
--- a/frontend/lib/lobby_page.dart
+++ b/frontend/lib/lobby_page.dart
@@ -44,10 +44,7 @@ class _LobbyPageState extends State<LobbyPage> {
         Navigator.push(
           context,
           MaterialPageRoute(
-            // El error está en que 'role' ahora debe ser el objeto 'data' completo,
-            // no solo un String.
-            // La siguiente línea es la correcta:
-            builder: (context) => RoleRevealPage(role: data),
+            builder: (context) => RoleRevealPage(role: {'role': data['role']}),
           ),
         );
       }

--- a/frontend/lib/role_reveal_page.dart
+++ b/frontend/lib/role_reveal_page.dart
@@ -12,15 +12,25 @@ class RoleRevealPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Verificamos si es un impostor o un jugador por la estructura del objeto
-    final bool isImpostor = role['name'] == 'IMPOSTOR';
+    // Extraemos el rol real, que está anidado dentro del mapa.
+    final dynamic roleData = role['role'];
+
+    // Comprobamos si el rol es un String y si es "IMPOSTOR".
+    final bool isImpostor = roleData is String && roleData == 'IMPOSTOR';
 
     if (isImpostor) {
-      // Si es impostor, mostramos la vista clásica
+      // Si es impostor, mostramos la vista de impostor.
       return buildImpostorView(context);
+    } else if (roleData is Map<String, dynamic>) {
+      // Si es un mapa, es un futbolista. Pasamos los datos del futbolista.
+      return buildPlayerView(context, roleData);
     } else {
-      // Si no, mostramos la nueva vista de futbolista con bandera
-      return buildPlayerView(context);
+      // Fallback por si los datos no tienen el formato esperado.
+      return Scaffold(
+        body: Center(
+          child: Text('Error: Rol desconocido'),
+        ),
+      );
     }
   }
 
@@ -60,9 +70,9 @@ class RoleRevealPage extends StatelessWidget {
   }
 
   // Widget para la vista del Futbolista con Bandera
-  Widget buildPlayerView(BuildContext context) {
-    final String playerName = role['name'] ?? 'N/A';
-    final String playerCountryCode = role['countryCode'] ?? 'AR'; // 'AR' como fallback por si acaso
+  Widget buildPlayerView(BuildContext context, Map<String, dynamic> playerData) {
+    final String playerName = playerData['name'] ?? 'N/A';
+    final String playerCountryCode = playerData['countryCode'] ?? 'AR'; // 'AR' como fallback por si acaso
 
     return Scaffold(
       backgroundColor: Colors.black,


### PR DESCRIPTION
The `RoleRevealPage` was misinterpreting the nested data structure of the role information sent by the server, causing an error when displaying the assigned role to the player.

This commit addresses the issue by:
1. Modifying `lobby_page.dart` to correctly wrap the role data in a map before passing it to `RoleRevealPage`.
2. Updating `role_reveal_page.dart` to parse the nested role data, correctly identifying whether the role is an 'IMPOSTOR' or a specific player, and rendering the appropriate view.
3. Adding a fallback in `role_reveal_page.dart` to handle any unexpected data formats gracefully.