### PR TITLE
feat: Change app name to Yuhu and clean up code

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -16,14 +16,6 @@ console.log(`✅ ${soccerPlayers.length} futbolistas cargados.`);
 
 let rooms = {};
 
-// // ===== NUEVA LISTA DE FUTBOLISTAS =====
-// // Puedes añadir todos los nombres que quieras aquí
-// const soccerPlayers = [
-//   "Messi", "Ronaldo", "Neymar", "Mbappé", "Haaland", "De Bruyne", 
-//   "Modrić", "Salah", "Vinícius Jr.", "Lewandowski", "Benzema", "Courtois",
-//   "Ronaldinho", "Zidane", "Maradona", "Pelé", "Kroos", "Di María"
-// ];
-
 const generateRoomCode = () => {
   let code = '';
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">   
     <uses-permission android:name="android.permission.INTERNET" />  
     <application
-        android:label="frontend"
+        android:label="Yuhu"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -114,28 +114,6 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  // void _createRoom() {
-  //   if (_nameController.text.isNotEmpty) {
-  //     // 1. Comentamos la línea original que se conecta al servidor
-  //     // _socket.emit('createRoom', _nameController.text);
-
-  //     // 2. AÑADIMOS NAVEGACIÓN DE PRUEBA:
-  //     // Cambia 'IMPOSTOR' por 'MESSI' para probar la otra vista
-  //     Navigator.push(
-  //       context,
-  //       MaterialPageRoute(
-  //         builder: (context) => RoleRevealPage(role: 'IMPOSTOR'),
-  //       ),
-  //     );
-
-  //   } else {
-  //     // El mensaje de error si el nombre está vacío se queda igual
-  //     ScaffoldMessenger.of(context).showSnackBar(
-  //       const SnackBar(content: Text('Por favor, introduce tu nombre')),
-  //     );
-  //   }
-  // }
-
   void _joinRoom() {
     if (_nameController.text.isNotEmpty && _roomCodeController.text.isNotEmpty) {
       _socket.emit('joinRoom', {


### PR DESCRIPTION
- Changed the Android application name to "Yuhu" in AndroidManifest.xml.
- Removed commented-out code from backend/index.js and frontend/lib/main.dart to improve code quality.
- Reverted the server URL in frontend/lib/main.dart to the production address.